### PR TITLE
Implement profiling servers with pprof

### DIFF
--- a/consumer/main.go
+++ b/consumer/main.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/lib/pq"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
+	_ "net/http/pprof" // This import is necessary to initialize the pprof endpoints
 )
 
 // Prometheus metrics
@@ -151,6 +152,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to listen: %v", err)
 	}
+
+	// Start the pprof server
+	go func() {
+		log.Println("Starting pprof server on :6060")
+		log.Fatal(http.ListenAndServe(":6060", nil)) // Bind to all network interfaces
+	}()
 
 	// Set up DB connection
 	db, err := sql.Open("postgres", "postgresql://admin:password@db:5432/tasks_db?sslmode=disable")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       dockerfile: Dockerfile.producer
     ports:
       - "2112:2112" # Expose Prometheus metrics port
+      - "6060:6060"  # Expose pprof for profiling
     depends_on:
       - db
 
@@ -28,6 +29,7 @@ services:
       dockerfile: Dockerfile.consumer
     ports:
       - "2113:2113" # Expose Prometheus metrics port
+      - "6061:6060" # Expose pprof for profiling for consumer
     depends_on:
       - db
 

--- a/producer/main.go
+++ b/producer/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	_ "net/http/pprof" // This import is necessary to initialize the pprof endpoints
 	"time"
 )
 
@@ -51,6 +52,12 @@ func main() {
 		http.Handle("/metrics", promhttp.Handler())
 		log.Println("Prometheus metrics available at http://localhost:2112/metrics")
 		log.Fatal(http.ListenAndServe(":2112", nil)) // Port for Prometheus metrics
+	}()
+
+	// Start the pprof server
+	go func() {
+		log.Println("Starting pprof server on :6060")
+		log.Fatal(http.ListenAndServe(":6060", nil)) // Bind to all network interfaces
 	}()
 
 	// Initialize DB connection


### PR DESCRIPTION
* Expose `producer` and `consumer` profiling ports